### PR TITLE
Add node test for training selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/characterCreation.test.js
+++ b/tests/characterCreation.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+global.window = {};
+const { gameData, character, selectTraining } = await import('../Game/scripts/characterCreation.js');
+
+test('selectTraining applies training and major correctly', () => {
+  const mockTraining = { name: 'Mock Academy', armorRating: 5, initiative: 2 };
+  gameData.trainings = [mockTraining];
+
+  // Reset character pieces this test cares about
+  character.training = null;
+  character.major = null;
+  character.attributes.intelligence = 0;
+  character.skillChoices = [];
+
+  selectTraining('Mock Academy', 'PsiOps', 'intelligence', 'Telepathy');
+
+  assert.strictEqual(character.training, mockTraining);
+  assert.strictEqual(character.major, 'PsiOps');
+  assert.strictEqual(character.attributes.intelligence, 1);
+  assert.deepStrictEqual(character.skillChoices, [{ name: 'Telepathy', level: 1 }]);
+});


### PR DESCRIPTION
## Summary
- setup package.json for ESM and testing
- add unit test covering `selectTraining`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fe21f76c08332ab5e71910f8c732c