### PR TITLE
Fix operator skill wording

### DIFF
--- a/Game/data/skills.json
+++ b/Game/data/skills.json
@@ -187,7 +187,7 @@
   "levels": {
     "1": "Operate vehicles without a skill check.",
     "2": "Advantage on stealth with vehicles or ships.",
-    "3": "Spot overwear and use solid checklists for vehicle maintenance.",
+    "3": "Spot wear and tear and use solid checklists for vehicle maintenance.",
     "4": "Advantage on challenging vehicle maneuvers.",
     "5": "You and your vehicle become one: repair it without a mechanic check (need parts/equipment)."
   }


### PR DESCRIPTION
## Summary
- fix a typo in Operator skill description about spotting wear and tear

## Testing
- `grep -n "Spot wear" -n Game/data/skills.json`

------
https://chatgpt.com/codex/tasks/task_e_683fe1f853408332a5870d990f7cdaf9