### PR TITLE
Fix major selection arguments

### DIFF
--- a/Game/scripts/characterCreationUI.js
+++ b/Game/scripts/characterCreationUI.js
@@ -234,7 +234,11 @@ window.displayTrainingCarousel = function(trainings, selectedIdx = 0) {
     btn.onclick = () => {
       // Pass the major and the school name to selectTraining
       const major = t.majors.find(m => m.name === btn.dataset.major);
-      window.selectTraining(t.name, major.attribute, major.skill);
+      // Pass training name, major name, attribute bonus and skill to the
+      // character creation logic. The previous code incorrectly omitted the
+      // major name and mis-ordered the arguments, which meant the selected
+      // major wasn't stored on the character.
+      window.selectTraining(t.name, major.name, major.attribute, major.skill);
       // Move to next step (Persona builder)
       uiStep++;
       renderStep();


### PR DESCRIPTION
## Summary
- fix argument order when selecting a training major

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683fdea73f308332af8333768cdda534