### PR TITLE
Implement era selection step

### DIFF
--- a/Game/css/characterCreation.css
+++ b/Game/css/characterCreation.css
@@ -64,9 +64,21 @@ body {
   cursor: pointer;
 }
 
-.carousel-card:hover {
+.carousel-card:hover,
+.major-card:hover,
+.option-card:hover,
+.skill-card:hover {
   box-shadow: 0 0 0 4px #00ffe1cc, 0 0 32px #3e54fd99;
   transform: scale(1.03);
+}
+
+.carousel-card.selected,
+.major-card.selected,
+.option-card.selected,
+.skill-card.selected,
+.era-card.selected {
+  box-shadow: 0 0 0 4px #00ffe1cc, 0 0 36px #3e54fdff;
+  transform: scale(1.05);
 }
 
 .neon-frame {
@@ -166,6 +178,8 @@ button:focus { outline: 2px solid #14f1e1; }
   padding: 1rem 1.3rem;
   box-shadow: 0 0 8px #63e0ff55;
   margin-bottom: 0.5rem;
+  cursor: pointer;
+  transition: box-shadow 0.3s, transform 0.3s;
 }
 
 /* Training panel shown beside carousel during training step */
@@ -244,4 +258,54 @@ button:focus { outline: 2px solid #14f1e1; }
   padding: 1rem;
   flex: 1 1 260px;
   max-width: 300px;
+}
+
+/* Skill selection */
+.skill-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.skill-card {
+  background: #1d2233;
+  border: 1.5px solid #35f1f9;
+  border-radius: 10px;
+  padding: 1rem;
+  flex: 1 1 220px;
+  max-width: 260px;
+  cursor: pointer;
+  transition: box-shadow 0.3s, transform 0.3s;
+}
+
+/* Persona trait/contact cards */
+.option-card {
+  background: #1d2233;
+  border: 1px solid #35f1f9;
+  border-radius: 8px;
+  padding: 0.6rem 0.8rem;
+  min-width: 150px;
+  text-align: center;
+  cursor: pointer;
+  transition: box-shadow 0.3s, transform 0.3s;
+}
+
+.scroll-row {
+  display: flex;
+  overflow-x: auto;
+  gap: 0.8rem;
+  padding-bottom: 0.5rem;
+}
+
+.custom-select {
+  padding: 0.4rem 0.6rem;
+  border-radius: 8px;
+  background: #1d2233;
+  color: #e0e5ff;
+  border: 1px solid #35f1f9;
+}
+
+#trait-count, #contact-count {
+  margin-bottom: 0.5rem;
 }

--- a/Game/data/personaPresets.json
+++ b/Game/data/personaPresets.json
@@ -143,64 +143,32 @@
     "Completely callous"
   ],
   "traits": [
-    "Stealthy",
-    "Charismatic",
-    "Tactical thinker",
-    "Loyal",
-    "Paranoid",
-    "Ruthless",
-    "Honest",
-    "Quick-tempered",
-    "Wise",
-    "Observant",
-    "Resilient",
-    "Soft-spoken",
-    "Bold",
-    "Manipulative",
-    "Compassionate",
-    "Calculating"
+    { "name": "Stealthy", "category": "Combat" },
+    { "name": "Charismatic", "category": "Social" },
+    { "name": "Tactical thinker", "category": "Combat" },
+    { "name": "Loyal", "category": "Personality" },
+    { "name": "Paranoid", "category": "Personality" },
+    { "name": "Ruthless", "category": "Personality" },
+    { "name": "Honest", "category": "Personality" },
+    { "name": "Quick-tempered", "category": "Personality" },
+    { "name": "Wise", "category": "Personality" },
+    { "name": "Observant", "category": "Personality" },
+    { "name": "Resilient", "category": "Personality" },
+    { "name": "Soft-spoken", "category": "Social" },
+    { "name": "Bold", "category": "Personality" },
+    { "name": "Manipulative", "category": "Social" },
+    { "name": "Compassionate", "category": "Personality" },
+    { "name": "Calculating", "category": "Personality" }
   ],
   "contacts": [
-    {
-      "name": "Jax",
-      "relationship": "Ex-handler",
-      "note": "Knows too much"
-    },
-    {
-      "name": "Mira",
-      "relationship": "Black market medic",
-      "note": "Still owes you a favor"
-    },
-    {
-      "name": "Voss",
-      "relationship": "Smuggler",
-      "note": "Reliable when paid"
-    },
-    {
-      "name": "Reyna",
-      "relationship": "Detective",
-      "note": "Wants you to turn over a new leaf"
-    },
-    {
-      "name": "Thalor",
-      "relationship": "Mentor",
-      "note": "Believes in your potential"
-    },
-    {
-      "name": "Sylvia",
-      "relationship": "Archivist",
-      "note": "Access to ancient knowledge"
-    },
-    {
-      "name": "Corvin",
-      "relationship": "Rival",
-      "note": "Always one step ahead"
-    },
-    {
-      "name": "Elira",
-      "relationship": "Sibling",
-      "note": "Keeps your family secrets"
-    }
+    { "name": "Jax", "relationship": "Ex-handler", "note": "Knows too much", "category": "Negative" },
+    { "name": "Mira", "relationship": "Black market medic", "note": "Still owes you a favor", "category": "Neutral" },
+    { "name": "Voss", "relationship": "Smuggler", "note": "Reliable when paid", "category": "Neutral" },
+    { "name": "Reyna", "relationship": "Detective", "note": "Wants you to turn over a new leaf", "category": "Positive" },
+    { "name": "Thalor", "relationship": "Mentor", "note": "Believes in your potential", "category": "Positive" },
+    { "name": "Sylvia", "relationship": "Archivist", "note": "Access to ancient knowledge", "category": "Positive" },
+    { "name": "Corvin", "relationship": "Rival", "note": "Always one step ahead", "category": "Negative" },
+    { "name": "Elira", "relationship": "Sibling", "note": "Keeps your family secrets", "category": "Positive" }
   ],
   "appearanceDetails": {
     "eyeColors": [

--- a/Game/scripts/characterCreation.js
+++ b/Game/scripts/characterCreation.js
@@ -198,9 +198,9 @@ export function setPersonaOnCharacter(skillToBump = null) {
 // --- STEP 5: Skills (just info step, handled by UI) ---
 export function displaySkillSystemStep() {
   showPrompt(
-    `Step 5: Skills & Leveling. Skills have 5 levels. To level up, succeed at skill checks. Each level unlocks new features.`
+    `Step 5: Select a starting skill.`
   );
-  window.displaySkillXPInfo(gameData.skills);
+  window.displaySkillSelection(gameData.skills);
 }
 
 // --- STEP 6: Superpowers ---
@@ -253,6 +253,10 @@ function addOrLevelSkill(skillName, level) {
   else character.skillChoices.push({ name: skillName, level });
 }
 
+export function selectStartingSkill(skillName) {
+  addOrLevelSkill(skillName, 1);
+}
+
 function saveCharacter(charObj) {
   localStorage.setItem('currentCharacter', JSON.stringify(charObj));
 }
@@ -265,3 +269,4 @@ window.selectRace = selectRace;
 window.selectProfession = selectProfession;
 window.selectSuperpower = selectSuperpower;
 window.selectEra = selectEra;
+window.selectStartingSkill = selectStartingSkill;


### PR DESCRIPTION
## Summary
- add card-based era selector UI
- style selected era card
- add card-based selection for race, profession, and training
- implement trait/contact categories and card UI
- add skill selection and power carousel polish

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_683ffe3c7ea483329c67ee5f23832542