### PR TITLE
Implement summary screen and custom UI fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,15 @@ README.md
 
 ---
 
-*This document is both the spec and style guide for all contributors, human or AI.  
+*This document is both the spec and style guide for all contributors, human or AI.
 Update it alongside any major system change.*
+
+## 10. Recent Updates
+
+- Added a Summary step at the end of character creation. `displayCharacterSheet()`
+  renders the player's full selections in boxed sections and is triggered after
+  choosing an Era.
+- Introduced custom neon scrollbars and fixed positioning for navigation headers
+  and action buttons. Containers use `.summary-container` and `.summary-section`
+  styles for the summary screen.
 

--- a/Game/css/characterCreation.css
+++ b/Game/css/characterCreation.css
@@ -356,3 +356,69 @@ button:focus { outline: 2px solid #14f1e1; }
   max-height: 50vh;
   gap: 0.8rem;
 }
+/* Summary screen layout */
+.summary-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  gap: 1rem;
+}
+.summary-section {
+  width: 90%;
+  max-width: 700px;
+  background: rgba(20,30,40,0.85);
+  border: 1px solid #c0c0c0;
+  padding: 1rem;
+  border-radius: 12px;
+}
+.summary-section h3 { margin-top: 0; }
+
+/* Fixed navigation and controls */
+#progress-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  background: rgba(14,24,44,0.96);
+  padding: 0.5rem 0;
+}
+#creation-main { padding-top: 60px; }
+#carousel-controls {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+}
+#carousel { padding-bottom: 80px; }
+
+/* Custom Scrollbars */
+.scroll-column,
+.scroll-row,
+.training-majors,
+#training-panel {
+  scrollbar-width: thin;
+  scrollbar-color: #3e54fd transparent;
+}
+.scroll-column::-webkit-scrollbar,
+.scroll-row::-webkit-scrollbar,
+.training-majors::-webkit-scrollbar,
+#training-panel::-webkit-scrollbar {
+  width: 4px;
+}
+.scroll-column::-webkit-scrollbar-thumb,
+.scroll-row::-webkit-scrollbar-thumb,
+.training-majors::-webkit-scrollbar-thumb,
+#training-panel::-webkit-scrollbar-thumb {
+  background: #3e54fd;
+  box-shadow: 0 0 6px #14f1e1;
+  border-radius: 4px;
+}
+.scroll-column::-webkit-scrollbar-track,
+.scroll-row::-webkit-scrollbar-track,
+.training-majors::-webkit-scrollbar-track,
+#training-panel::-webkit-scrollbar-track {
+  background: transparent;
+}

--- a/Game/scripts/characterCreationUI.js
+++ b/Game/scripts/characterCreationUI.js
@@ -861,6 +861,81 @@ window.displayEraSelector = function () {
   prevBtn.onclick = () => { prevStep(); uiStep--; renderStep(); };
   nextBtn.onclick = () => {};
 };
+
+// --- Summary Character Sheet ---
+window.displayCharacterSheet = function (charData) {
+  content.innerHTML = '';
+
+  const container = document.createElement('div');
+  container.className = 'summary-container';
+
+  const makeSection = (title, html) => {
+    const sec = document.createElement('div');
+    sec.className = 'summary-section neon-frame';
+    sec.innerHTML = `<h3>${title}</h3>${html}`;
+    return sec;
+  };
+
+  if (charData.race) {
+    container.appendChild(makeSection('Race', `<p>${charData.race.name}</p><p>Age: ${charData.age || ''}</p>`));
+  }
+  if (charData.profession) {
+    container.appendChild(makeSection('Profession', `<p>${charData.profession.name}</p>`));
+  }
+  if (charData.training) {
+    container.appendChild(makeSection('Training', `<p>${charData.training.name}</p><p>Major: ${charData.major || ''}</p>`));
+  }
+
+  const attrs = Object.entries(charData.attributes || {})
+    .map(([k,v]) => `${k}: ${v}`)
+    .join(', ');
+  if (attrs) container.appendChild(makeSection('Attributes', `<p>${attrs}</p>`));
+
+  const persona = charData.persona || {};
+  const personaHtml = `
+    <p><b>Personality:</b> ${persona.personality || ''}</p>
+    <p><b>Motivation:</b> ${persona.motivation || ''}</p>
+    <p><b>Plan:</b> ${persona.plan || ''}</p>
+    <p><b>Hardship:</b> ${persona.hardship || ''}</p>
+    <p><b>Goals:</b> ${(persona.goals?.short)||''} / ${(persona.goals?.long)||''}</p>
+    <p><b>Empathy:</b> ${persona.empathy || ''}</p>
+    <p><b>Appearance:</b> ${(persona.appearance?.description)||''}</p>`;
+  container.appendChild(makeSection('Persona', personaHtml));
+
+  if (Array.isArray(persona.traits)) {
+    container.appendChild(makeSection('Traits', `<p>${persona.traits.join(', ')}</p>`));
+  }
+  if (Array.isArray(persona.contacts)) {
+    const contactText = persona.contacts.map(c=>`${c.name} (${c.relationship})`).join(', ');
+    container.appendChild(makeSection('Contacts', `<p>${contactText}</p>`));
+  }
+
+  if (Array.isArray(persona.appearance?.features)) {
+    container.appendChild(makeSection('Features', `<p>${persona.appearance.features.join(', ')}</p>`));
+  }
+
+  if (Array.isArray(charData.skillChoices)) {
+    const skillText = charData.skillChoices.map(s=>`${s.name} (Lv${s.level})`).join(', ');
+    container.appendChild(makeSection('Skills', `<p>${skillText}</p>`));
+  }
+
+  if (Array.isArray(charData.superpowers)) {
+    const powerText = charData.superpowers.map(p=>`${p.power} (Lv${p.level})`).join(', ');
+    container.appendChild(makeSection('Superpowers', `<p>${powerText}</p>`));
+  }
+
+  if (charData.era) {
+    container.appendChild(makeSection('Era', `<p>${charData.era}</p>`));
+  }
+
+  content.appendChild(container);
+
+  nextBtn.textContent = 'Confirm';
+  prevBtn.disabled = false;
+  nextBtn.disabled = false;
+  prevBtn.onclick = () => { prevStep(); uiStep--; renderStep(); };
+  nextBtn.onclick = () => { nextStep(); uiStep++; renderStep(); };
+};
 window.displayPersonaBuilder = window.displayPersonaStep; // <-- this covers the "preset or build" screen
 
 


### PR DESCRIPTION
## Summary
- add summary character sheet renderer
- style summary containers and custom neon scrollbars
- fix navigation/header positions
- document UI updates in AGENTS.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684010d26c0083328b542332768561f3