### PR TITLE
Add saveManager for persistent character saves

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,4 +142,6 @@ Update it alongside any major system change.*
 - Introduced custom neon scrollbars and fixed positioning for navigation headers
   and action buttons. Containers use `.summary-container` and `.summary-section`
   styles for the summary screen.
+- Implemented `saveManager.js` for persistent character saves. Save data now
+  includes the schema version to allow future migrations.
 

--- a/Game/scripts/characterCreation.js
+++ b/Game/scripts/characterCreation.js
@@ -1,5 +1,7 @@
 // characterCreation.js
 
+import { saveCharacter as persistCharacter, clearSavedCharacter } from './saveManager.js';
+
 // --- Game Data (mutable, shared across modules) ---
 export const gameData = {
   races: [],
@@ -240,7 +242,7 @@ export function displaySummaryStep() {
 }
 export function finalizeCharacter() {
   character.inspiration = true;
-  saveCharacter(character);
+  persistCharacter(character);
   showPrompt(`You gain inspiration for completing character creation. Let's play!`);
   if (window.parent && window.parent.setState) window.parent.setState('mainGame');
 }
@@ -257,12 +259,8 @@ export function selectStartingSkill(skillName) {
   addOrLevelSkill(skillName, 1);
 }
 
-function saveCharacter(charObj) {
-  localStorage.setItem('currentCharacter', JSON.stringify(charObj));
-}
-
 export function resetSavedCharacter() {
-  localStorage.removeItem('currentCharacter');
+  clearSavedCharacter();
 }
 
 // UI helper stubs (will be overwritten by UI file)

--- a/Game/scripts/saveManager.js
+++ b/Game/scripts/saveManager.js
@@ -1,0 +1,42 @@
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+let VERSION = '1.0.0';
+try {
+  const path = join(dirname(fileURLToPath(import.meta.url)), '../../schema.json');
+  const data = JSON.parse(readFileSync(path, 'utf8'));
+  VERSION = data.schemaVersion;
+} catch {
+  // Browser environment will fallback to this default
+}
+
+const STORAGE_KEY = 'currentCharacter';
+
+export function saveCharacter(data) {
+  const payload = { version: VERSION, character: data };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+}
+
+export function loadCharacter() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    const payload = JSON.parse(raw);
+    if (payload.version !== VERSION) {
+      return migrateCharacter(payload);
+    }
+    return payload.character;
+  } catch {
+    return null;
+  }
+}
+
+function migrateCharacter(payload) {
+  // Placeholder for future version migrations
+  return payload.character;
+}
+
+export function clearSavedCharacter() {
+  localStorage.removeItem(STORAGE_KEY);
+}

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": "1.0.0",
+  "description": "Core data and rule schema for Infinite Ages. Bump this version whenever refactoring changes data structures or gameplay rules." 
+}

--- a/tests/saveManager.test.js
+++ b/tests/saveManager.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { saveCharacter, loadCharacter, clearSavedCharacter } from '../Game/scripts/saveManager.js';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const schemaPath = join(dirname(fileURLToPath(import.meta.url)), '../schema.json');
+const schema = JSON.parse(readFileSync(schemaPath, 'utf8'));
+
+global.localStorage = {
+  data: {},
+  setItem(key, val) { this.data[key] = val; },
+  getItem(key) { return this.data[key] ?? null; },
+  removeItem(key) { delete this.data[key]; }
+};
+
+test('save and load character retains schema version', () => {
+  const char = { name: 'Tester', era: 'Modern' };
+  saveCharacter(char);
+  const loaded = loadCharacter();
+  assert.deepStrictEqual(loaded, char);
+
+  const raw = global.localStorage.data['currentCharacter'];
+  const stored = JSON.parse(raw);
+  assert.strictEqual(stored.version, schema.schemaVersion);
+
+  clearSavedCharacter();
+  assert.strictEqual(global.localStorage.data['currentCharacter'], undefined);
+});


### PR DESCRIPTION
## Summary
- implement `saveManager.js` module to handle versioned character saves
- use saveManager in `characterCreation.js`
- document persistent save system in `AGENTS.md`
- add tests for saveManager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68403d8ed1148332a33e19ba8d8ee2b0