### PR TITLE
Fix asset paths after moving index.html

### DIFF
--- a/Game/scripts/gamestate.js
+++ b/Game/scripts/gamestate.js
@@ -30,7 +30,7 @@ async function render() {
   if (state === 'characterCreation') {
     // Load character creation screen/module
     const html = document.createElement('iframe');
-    html.src = 'Game/character-creation.html';
+    html.src = '/Game/character-creation.html';
     html.style.width = '100%';
     html.style.height = '700px';
     html.style.border = 'none';

--- a/codexlog.md
+++ b/codexlog.md
@@ -1,3 +1,4 @@
 1. Fixed 404 errors by updating index.html to use absolute paths for game assets.
 2. Updated server paths to be absolute using __dirname for reliable asset loading.
 3. Added base href tag and absolute iframe path to ensure asset loading after moving index.html to /public.
+4. Verified server serves CSS and JS with correct MIME types after the move and confirmed all tests pass.

--- a/codexlog.md
+++ b/codexlog.md
@@ -1,2 +1,3 @@
 1. Fixed 404 errors by updating index.html to use absolute paths for game assets.
 2. Updated server paths to be absolute using __dirname for reliable asset loading.
+3. Added base href tag and absolute iframe path to ensure asset loading after moving index.html to /public.

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Infinite Ages - Main Game</title>
+  <base href="/">
   <link rel="stylesheet" href="/Game/css/styles.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- set `<base href="/">` in `public/index.html`
- reference the character creation page with an absolute path
- document latest path fixes in `codexlog.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840c50b48c883328cd73117f511fd18