### PR TITLE
Fix schema.json path for save manager

### DIFF
--- a/codexlog.md
+++ b/codexlog.md
@@ -6,3 +6,4 @@
 5. Updated server static path to /public/Game and fixed test imports after moving files. All tests pass.
 6. Verified character creation HTML references local assets correctly and ensured tests pass.
 7. Updated characterCreationUI.js to fetch JSON data from /Game/data with a helper function for error logging. All tests pass.
+8. Added endpoint to serve schema.json from server and updated saveManager.js to load it correctly in browser and tests. Tests remain green.

--- a/public/Game/scripts/saveManager.js
+++ b/public/Game/scripts/saveManager.js
@@ -1,13 +1,27 @@
 let VERSION = '1.0.0';
 try {
-  const url = new URL('../../schema.json', import.meta.url);
-  const res = await fetch(url);
-  if (res.ok) {
-    const data = await res.json();
+  let data = null;
+  try {
+    const url = new URL('../../schema.json', import.meta.url);
+    const res = await fetch(url);
+    if (res.ok) {
+      data = await res.json();
+    }
+  } catch { /* fetch may fail in non-browser environment */ }
+
+  if (!data) {
+    const { readFileSync } = await import('fs');
+    const { dirname, join } = await import('path');
+    const { fileURLToPath } = await import('url');
+    const root = dirname(dirname(dirname(dirname(fileURLToPath(import.meta.url)))));
+    const schemaPath = join(root, 'schema.json');
+    data = JSON.parse(readFileSync(schemaPath, 'utf8'));
+  }
+  if (data && data.schemaVersion) {
     VERSION = data.schemaVersion;
   }
-} catch {
-  // Browser or test environment may fail to load schema; default remains
+} catch (err) {
+  console.log('Could not load schema.json:', err.message);
 }
 
 const STORAGE_KEY = 'currentCharacter';

--- a/server.js
+++ b/server.js
@@ -23,6 +23,10 @@ app.use(express.json());
 app.use(express.static(PUBLIC_DIR));
 app.use('/Game', express.static(GAME_DIR));
 
+app.get('/schema.json', (req, res) => {
+  res.sendFile(path.join(__dirname, 'schema.json'));
+});
+
 app.get('/', (req, res) => {
   res.sendFile(path.join(PUBLIC_DIR, 'index.html'));
 });


### PR DESCRIPTION
## Summary
- serve `schema.json` directly from the server
- load `schema.json` in `saveManager.js` in browser and test environments
- log updated in `codexlog.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840ec311c148332b862595665ea6b0a