### PR TITLE
Fix schema endpoint order

### DIFF
--- a/codexlog.md
+++ b/codexlog.md
@@ -7,3 +7,4 @@
 6. Verified character creation HTML references local assets correctly and ensured tests pass.
 7. Updated characterCreationUI.js to fetch JSON data from /Game/data with a helper function for error logging. All tests pass.
 8. Added endpoint to serve schema.json from server and updated saveManager.js to load it correctly in browser and tests. Tests remain green.
+9. Reordered server middleware so schema.json is served before static routing to fix 404 errors.

--- a/server.js
+++ b/server.js
@@ -20,12 +20,14 @@ const GAME_DIR = path.join(PUBLIC_DIR, 'Game');
 
 app.use(cors());
 app.use(express.json());
-app.use(express.static(PUBLIC_DIR));
-app.use('/Game', express.static(GAME_DIR));
 
+// Serve schema.json directly before static middleware so it isn't intercepted
 app.get('/schema.json', (req, res) => {
   res.sendFile(path.join(__dirname, 'schema.json'));
 });
+
+app.use(express.static(PUBLIC_DIR));
+app.use('/Game', express.static(GAME_DIR));
 
 app.get('/', (req, res) => {
   res.sendFile(path.join(PUBLIC_DIR, 'index.html'));


### PR DESCRIPTION
## Summary
- serve `schema.json` before static middleware so fetch works
- document fix in codexlog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840ed8af96c8332ba96bddc2bc6daac