### PR TITLE
Fix data paths for character creation

### DIFF
--- a/codexlog.md
+++ b/codexlog.md
@@ -9,3 +9,4 @@
 8. Added endpoint to serve schema.json from server and updated saveManager.js to load it correctly in browser and tests. Tests remain green.
 9. Reordered server middleware so schema.json is served before static routing to fix 404 errors.
 10. Pointed server and scripts to schema.json under /public/Game/data/schema. Updated saveManager and its test, fixed character creation JSON paths, removed unused node-fetch dependency and deleted empty creation.js. All tests pass.
+11. Created dataUtils module to resolve character creation data paths and updated characterCreationUI.js to use it. Added test for path resolution.

--- a/public/Game/scripts/characterCreationUI.js
+++ b/public/Game/scripts/characterCreationUI.js
@@ -8,31 +8,20 @@ import {
   selectRace, selectProfession, selectTraining,
   playerPersona, character, setPersonaOnCharacter
 } from './characterCreation.js';
+import {
+  fetchJsonFile,
+  resolveCharacterCreationPath
+} from './dataUtils.js';
 
 let personaData = null;
 
-async function fetchJsonFile(path) {
-  try {
-    const res = await fetch(path);
-    if (!res.ok) {
-      console.log(`Failed to load ${path}: ${res.status}`);
-      return null;
-    }
-    return await res.json();
-  } catch (err) {
-    console.log(`Error loading ${path}: ${err.message}`);
-    return null;
-  }
-}
-
 async function loadAllData() {
-  const base = '/Game/data/character%20creation/';
-  gameData.races = await fetchJsonFile(base + 'races.json') || [];
-  gameData.professions = await fetchJsonFile(base + 'professions.json') || [];
-  gameData.trainings = await fetchJsonFile(base + 'trainings.json') || [];
-  gameData.skills = await fetchJsonFile(base + 'skills.json') || [];
-  gameData.powers = await fetchJsonFile(base + 'powers.json') || [];
-  gameData.personaPresets = await fetchJsonFile(base + 'personaPresets.json');
+  gameData.races = await fetchJsonFile(resolveCharacterCreationPath('races.json')) || [];
+  gameData.professions = await fetchJsonFile(resolveCharacterCreationPath('professions.json')) || [];
+  gameData.trainings = await fetchJsonFile(resolveCharacterCreationPath('trainings.json')) || [];
+  gameData.skills = await fetchJsonFile(resolveCharacterCreationPath('skills.json')) || [];
+  gameData.powers = await fetchJsonFile(resolveCharacterCreationPath('powers.json')) || [];
+  gameData.personaPresets = await fetchJsonFile(resolveCharacterCreationPath('personaPresets.json'));
   personaData = gameData.personaPresets;
   console.log('personaData loaded:', personaData);
 }

--- a/public/Game/scripts/dataUtils.js
+++ b/public/Game/scripts/dataUtils.js
@@ -1,0 +1,19 @@
+export const CHARACTER_CREATION_BASE = new URL('../data/character creation/', import.meta.url);
+
+export function resolveCharacterCreationPath(fileName) {
+  return new URL(fileName, CHARACTER_CREATION_BASE).pathname;
+}
+
+export async function fetchJsonFile(path) {
+  try {
+    const res = await fetch(path);
+    if (!res.ok) {
+      console.log(`Failed to load ${path}: ${res.status}`);
+      return null;
+    }
+    return await res.json();
+  } catch (err) {
+    console.log(`Error loading ${path}: ${err.message}`);
+    return null;
+  }
+}

--- a/tests/dataUtils.test.js
+++ b/tests/dataUtils.test.js
@@ -1,0 +1,9 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveCharacterCreationPath } from '../public/Game/scripts/dataUtils.js';
+
+const result = resolveCharacterCreationPath('races.json');
+
+test('resolveCharacterCreationPath points to character creation data', () => {
+  assert.ok(result.endsWith('/Game/data/character%20creation/races.json'));
+});


### PR DESCRIPTION
## Summary
- move JSON fetch helper to new `dataUtils` module
- update `characterCreationUI.js` to use helper for robust data paths
- add unit test for new path resolver
- document change in `codexlog.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840f2f6bb3883328e6846ba21a4f50d