### PR TITLE
Fix path handling for character creation JSON

### DIFF
--- a/codexlog.md
+++ b/codexlog.md
@@ -12,3 +12,5 @@
 11. Documented current file structure in SYSTEM_SPEC and filled in last update date. All tests still pass.
 12. Created dataUtils module to resolve character creation data paths and updated characterCreationUI.js to use it. Added test for path resolution.
 
+
+13. Fixed character creation data paths by using a constant base URL in dataUtils to avoid incorrect imports. All tests pass.

--- a/public/Game/scripts/dataUtils.js
+++ b/public/Game/scripts/dataUtils.js
@@ -1,7 +1,10 @@
-export const CHARACTER_CREATION_BASE = new URL('../data/character creation/', import.meta.url);
+// Root path for all character creation JSON data. Using a fixed
+// absolute path avoids issues when the page is served from different
+// directories or nested routes.
+export const CHARACTER_CREATION_BASE = '/Game/data/character%20creation/';
 
 export function resolveCharacterCreationPath(fileName) {
-  return new URL(fileName, CHARACTER_CREATION_BASE).pathname;
+  return `${CHARACTER_CREATION_BASE}${fileName}`;
 }
 
 export async function fetchJsonFile(path) {


### PR DESCRIPTION
## Summary
- fix data path generation in `dataUtils` to prevent missing JSON loads
- document change in `codexlog`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840f52147d483328408eac78b0ac7b3