### PR TITLE
Add data load verification and error modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ http://localhost:3000/Game/character-creation.html
 ```
 
 Opening the HTML files directly from the filesystem will prevent `fetch()` from loading JSON data.
+
+## Troubleshooting
+
+If the character creator displays a message that game data could not be loaded, ensure the Express server is running on port 3000. Once the server is active, refresh the page to try again.

--- a/codexlog.md
+++ b/codexlog.md
@@ -21,3 +21,4 @@
 17. Improved JSON import fallback in dataUtils to work with both "with" and "assert" syntaxes so persona presets load in newer Node versions. All tests pass.
 18. Added README with instructions to start the server before loading game pages and inserted a file:// warning script in character-creation.html.
 19. Renamed character creation data folder to `character-creation` to avoid URL encoding issues. Updated dataUtils path, tests, and SYSTEM_SPEC. All tests pass.
+20. Added missing data detection in characterCreationUI with modal error display using new uiUtils module. Created uiUtils.test for isDataLoaded. Updated CSS with error modal styles and README troubleshooting tips.

--- a/public/Game/css/characterCreation.css
+++ b/public/Game/css/characterCreation.css
@@ -471,3 +471,19 @@ button:focus { outline: 2px solid #14f1e1; }
 #training-panel::-webkit-scrollbar-track {
   background: transparent;
 }
+
+/* Error modal shown when data fails to load */
+.error-modal {
+  position: fixed;
+  top: 30vh;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(14,24,44,0.96);
+  color: #e0e5ff;
+  padding: 1.5rem 2rem;
+  border-radius: 12px;
+  max-width: 420px;
+  text-align: center;
+  box-shadow: 0 0 20px #00ffe1aa, 0 0 10px #5e4fffaa;
+  z-index: 2000;
+}

--- a/public/Game/scripts/characterCreationUI.js
+++ b/public/Game/scripts/characterCreationUI.js
@@ -12,6 +12,7 @@ import {
   fetchJsonFile,
   resolveCharacterCreationPath
 } from './dataUtils.js';
+import { verifyDataLoaded } from './uiUtils.js';
 
 let personaData = null;
 
@@ -30,6 +31,7 @@ async function loadAllData() {
   personaData = gameData.personaPresets;
   console.log('Persona presets', personaData ? 'loaded' : 'missing');
 }
+
 
 
 const content = document.getElementById('carousel-content');
@@ -55,6 +57,9 @@ let uiStep = 0;
 
 async function init() {
   await loadAllData();
+  if (!verifyDataLoaded(gameData, personaData)) {
+    return;
+  }
   uiStep = 0;
   initProgressNav();
   renderStep();

--- a/public/Game/scripts/uiUtils.js
+++ b/public/Game/scripts/uiUtils.js
@@ -1,0 +1,30 @@
+export function isDataLoaded(gameData, personaData) {
+  return (
+    gameData.races?.length > 0 &&
+    gameData.professions?.length > 0 &&
+    gameData.trainings?.length > 0 &&
+    gameData.skills?.length > 0 &&
+    gameData.powers?.length > 0 &&
+    !!personaData
+  );
+}
+
+export function showDataLoadError() {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById('data-error-modal')) return;
+  const modal = document.createElement('div');
+  modal.id = 'data-error-modal';
+  modal.className = 'error-modal neon-frame';
+  modal.textContent =
+    'Game data could not be loaded. Please verify the server is running and refresh this page.';
+  document.body.appendChild(modal);
+}
+
+export function verifyDataLoaded(gameData, personaData) {
+  if (!isDataLoaded(gameData, personaData)) {
+    console.log('Game data failed to load. Check that the server is running.');
+    showDataLoadError();
+    return false;
+  }
+  return true;
+}

--- a/tests/uiUtils.test.js
+++ b/tests/uiUtils.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { isDataLoaded } from '../public/Game/scripts/uiUtils.js';
+
+const emptyData = {
+  races: [],
+  professions: [],
+  trainings: [],
+  skills: [],
+  powers: []
+};
+
+const fullData = {
+  races: [1],
+  professions: [1],
+  trainings: [1],
+  skills: [1],
+  powers: [1]
+};
+
+test('isDataLoaded returns false when any data missing', () => {
+  assert.strictEqual(isDataLoaded(emptyData, null), false);
+});
+
+test('isDataLoaded returns true when all data present', () => {
+  assert.strictEqual(isDataLoaded(fullData, {}), true);
+});


### PR DESCRIPTION
## Summary
- detect missing character creation data
- show an error modal if game data fails to load
- extract data check helpers into `uiUtils.js`
- style a futuristic error modal
- document troubleshooting tips in README
- test new `isDataLoaded` helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68413f8afa98833295d4d0fecc837f7d