### PR TITLE
Allow server port override

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project uses a simple Express server to serve game files. To ensure all JSO
 npm start
 ```
 
-This command runs `server.js` on port 3000.
+This command runs `server.js` on port 3000 by default. You can set the `PORT` environment variable to use a different port.
 
 ## Open the Character Creator
 
@@ -23,11 +23,11 @@ Opening the HTML files directly from the filesystem will prevent `fetch()` from 
 
 ## Troubleshooting
 
-If the character creator displays a message that game data could not be loaded, ensure the Express server is running on port 3000. Once the server is active, refresh the page to try again.
+If the character creator displays a message that game data could not be loaded, ensure the Express server is running. The server defaults to port 3000 unless you set the `PORT` environment variable. Once the server is active, refresh the page to try again.
 
 ## Verify the Server and Data Requests
 
-Visit `http://localhost:3000/` in your browser after running `npm start` to make sure the server is up. You should see the main game page. If the page does not load, the server is not running.
+Visit `http://localhost:3000/` in your browser after running `npm start` to make sure the server is up. Replace `3000` with your `PORT` value if you configured a different port. You should see the main game page. If the page does not load, the server is not running.
 
 Open the browser developer tools (usually with **F12** or **Ctrl+Shift+I**) and check the **Console** and **Network** tabs. Look for any 404 or failed requests for `.json` files. Every data file resides under `/public/Game/data`, so missing files will show paths from that directory in the network log.
 

--- a/codexlog.md
+++ b/codexlog.md
@@ -24,3 +24,4 @@
 
 
 
+24. Made server port configurable via PORT env variable and updated README with instructions about overriding the default port.

--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'url';
 dotenv.config();
 
 const app = express();
-const PORT = 3000;
+const PORT = process.env.PORT || 3000;
 
 // Resolve paths relative to this file so the server works from any cwd
 const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
## Summary
- make `PORT` overridable via environment variable
- document the optional `PORT` env var in the README
- log the change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684144e54f3883328efa0e934ba150e9