### PR TITLE
Insert base href to character creation

### DIFF
--- a/codexlog.md
+++ b/codexlog.md
@@ -24,3 +24,4 @@
 
 
 
+24. Inserted base href tag in character-creation.html and updated CSS and script paths to absolute /Game references. Verified links load and all tests pass.

--- a/public/Game/character-creation.html
+++ b/public/Game/character-creation.html
@@ -2,8 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <base href="/">
   <title>Infinite Ages: Character Creation</title>
-  <link rel="stylesheet" href="css/characterCreation.css">
+  <link rel="stylesheet" href="/Game/css/characterCreation.css">
 </head>
 <body>
   <div id="creation-bg"></div>
@@ -22,7 +23,7 @@
       <p id="prompt-text"></p>
     </section>
   </main>
-  <script type="module" src="scripts/characterCreationUI.js"></script>
+  <script type="module" src="/Game/scripts/characterCreationUI.js"></script>
   <script>
     if (location.protocol === 'file:') {
       document.body.innerHTML = '<main style="padding:2rem;text-align:center;color:white;font-family:sans-serif">Please run <code>npm start</code> and open <a href="http://localhost:3000/Game/character-creation.html">http://localhost:3000/Game/character-creation.html</a> to use the character creator.</main>';


### PR DESCRIPTION
## Summary
- add a `<base href="/">` tag to character-creation.html
- update stylesheet and script paths to absolute `/Game` locations
- document the change in `codexlog.md`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684144ebbeb083328629925852f0a67b