### PR TITLE
Fix character data path resolution

### DIFF
--- a/codexlog.md
+++ b/codexlog.md
@@ -33,4 +33,6 @@
 
 24. Added null checks after each fetchJsonFile call in characterCreationUI with a helper that logs missing file paths and updates the modal via showDataLoadError. Modified showDataLoadError to accept a file path so the message identifies the failed load. All tests pass.
 
+25. Revised dataUtils to build root-relative paths so fetch works on Express server. Updated fetchJsonFile fallback and adjusted fetchJsonFile.test.js accordingly. All tests pass.
+
 

--- a/public/Game/scripts/dataUtils.js
+++ b/public/Game/scripts/dataUtils.js
@@ -1,15 +1,14 @@
-// Base path for all character creation JSON files. The path is
-// resolved relative to this script so it works whether the page is
-// served via HTTP or opened directly from the filesystem.
-// Updated path uses a hyphen to avoid issues with spaces in URLs
-const CHARACTER_CREATION_BASE = new URL('../data/character-creation/', import.meta.url);
+// Base path for all character creation JSON files.
+// Using a root-relative HTTP path ensures fetch() works when assets
+// are served via the Express/static server.
+const CHARACTER_CREATION_BASE = '/Game/data/character-creation/';
 
 export function getCharacterCreationBase() {
-  return CHARACTER_CREATION_BASE.href;
+  return CHARACTER_CREATION_BASE;
 }
 
 export function resolveCharacterCreationPath(fileName) {
-  return new URL(fileName, CHARACTER_CREATION_BASE).href;
+  return `${CHARACTER_CREATION_BASE}${fileName}`;
 }
 
 export async function fetchJsonFile(path) {
@@ -23,7 +22,8 @@ export async function fetchJsonFile(path) {
   } catch (error) {
     console.log(`Error loading ${path}: ${error.message}`);
     try {
-      const modulePath = new URL(path, import.meta.url).href;
+      // Build a file path relative to this script for Node environments.
+      const modulePath = new URL('..' + path.replace('/Game', ''), import.meta.url).href;
       // Support both import assertion and the newer `with` syntax
       try {
         const module = await import(modulePath, { with: { type: 'json' } });

--- a/tests/fetchJsonFile.test.js
+++ b/tests/fetchJsonFile.test.js
@@ -5,10 +5,11 @@ import { fetchJsonFile, resolveCharacterCreationPath } from '../public/Game/scri
 const jsonPath = resolveCharacterCreationPath('races.json');
 
 async function directImport(path) {
+  const filePath = new URL('../public' + path, import.meta.url).href;
   try {
-    return (await import(path, { with: { type: 'json' } })).default;
+    return (await import(filePath, { with: { type: 'json' } })).default;
   } catch {
-    return (await import(path, { assert: { type: 'json' } })).default;
+    return (await import(filePath, { assert: { type: 'json' } })).default;
   }
 }
 


### PR DESCRIPTION
## Summary
- make dataUtils build root-relative paths
- update fetchJsonFile's dynamic import fallback
- adjust fetchJsonFile.test for new import path
- document changes in codexlog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841511dd1148332821bed51b1b107cf