### PR TITLE
Fix dataUtils path for express

### DIFF
--- a/codexlog.md
+++ b/codexlog.md
@@ -33,4 +33,6 @@
 
 24. Added null checks after each fetchJsonFile call in characterCreationUI with a helper that logs missing file paths and updates the modal via showDataLoadError. Modified showDataLoadError to accept a file path so the message identifies the failed load. All tests pass.
 
+28. Revised dataUtils to build root-relative paths so fetch works under Express. Updated import fallback logic and adjusted fetchJsonFile.test.js. All tests pass.
+
 

--- a/public/Game/scripts/dataUtils.js
+++ b/public/Game/scripts/dataUtils.js
@@ -1,15 +1,14 @@
-// Base path for all character creation JSON files. The path is
-// resolved relative to this script so it works whether the page is
-// served via HTTP or opened directly from the filesystem.
-// Updated path uses a hyphen to avoid issues with spaces in URLs
-const CHARACTER_CREATION_BASE = new URL('../data/character-creation/', import.meta.url);
+// Base path for all character creation JSON files. Using a fixed
+// root-relative path ensures fetch works when assets are served via
+// Express or any static HTTP server.
+const CHARACTER_CREATION_BASE = '/Game/data/character-creation/';
 
 export function getCharacterCreationBase() {
-  return CHARACTER_CREATION_BASE.href;
+  return CHARACTER_CREATION_BASE;
 }
 
 export function resolveCharacterCreationPath(fileName) {
-  return new URL(fileName, CHARACTER_CREATION_BASE).href;
+  return `${CHARACTER_CREATION_BASE}${fileName}`;
 }
 
 export async function fetchJsonFile(path) {
@@ -23,7 +22,9 @@ export async function fetchJsonFile(path) {
   } catch (error) {
     console.log(`Error loading ${path}: ${error.message}`);
     try {
-      const modulePath = new URL(path, import.meta.url).href;
+      const modulePath = path.startsWith('/')
+        ? new URL(`../../${path}`, import.meta.url).href
+        : new URL(path, import.meta.url).href;
       // Support both import assertion and the newer `with` syntax
       try {
         const module = await import(modulePath, { with: { type: 'json' } });

--- a/tests/fetchJsonFile.test.js
+++ b/tests/fetchJsonFile.test.js
@@ -5,10 +5,11 @@ import { fetchJsonFile, resolveCharacterCreationPath } from '../public/Game/scri
 const jsonPath = resolveCharacterCreationPath('races.json');
 
 async function directImport(path) {
+  const fileUrl = new URL(`../public${path}`, import.meta.url).href;
   try {
-    return (await import(path, { with: { type: 'json' } })).default;
+    return (await import(fileUrl, { with: { type: 'json' } })).default;
   } catch {
-    return (await import(path, { assert: { type: 'json' } })).default;
+    return (await import(fileUrl, { assert: { type: 'json' } })).default;
   }
 }
 


### PR DESCRIPTION
## Summary
- update path helpers to use root-relative URLs for character creation JSON
- improve fetchJsonFile import fallback for root paths
- adjust test for new base path
- document changes in codexlog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68415242b1c48332966a978ae937e71c